### PR TITLE
feat: Make Ollama URL and default model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,20 @@ JRVS can now act as an **MCP Client**, connecting to MCP servers to access exter
 
 ## 🛠️ Configuration
 
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OLLAMA_BASE_URL` | `http://localhost:11434` | URL of the Ollama API server |
+| `OLLAMA_DEFAULT_MODEL` | `deepseek-r1:14b` | Default model to use |
+
+Example for connecting to a remote Ollama instance:
+```bash
+export OLLAMA_BASE_URL="http://192.168.1.100:11434"
+export OLLAMA_DEFAULT_MODEL="llama3:8b"
+python main.py
+```
+
 ### Command Line Options
 
 ```bash

--- a/config.py
+++ b/config.py
@@ -16,8 +16,8 @@ DATABASE_PATH = DATA_DIR / "jarvis.db"
 VECTOR_INDEX_PATH = DATA_DIR / "faiss_index"
 
 # Ollama settings
-OLLAMA_BASE_URL = "http://localhost:11434"
-DEFAULT_MODEL = "deepseek-r1:14b"
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+DEFAULT_MODEL = os.environ.get("OLLAMA_DEFAULT_MODEL", "deepseek-r1:14b")
 
 # Timeout settings (in seconds)
 TIMEOUTS = {


### PR DESCRIPTION
Make Ollama URL and default model configurable via environment variables

Allow users to configure OLLAMA_BASE_URL and OLLAMA_DEFAULT_MODEL via environment variables, enabling use with remote Ollama instances without modifying code. Falls back to localhost:11434 and deepseek-r1:14b respectively.

Also updated README.md with documentation for the new environment variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)